### PR TITLE
feat: add show/hide password toggle on register form

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -195,6 +195,34 @@ body {
   box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.1);
 }
 
+.password-wrapper {
+  position: relative;
+  display: flex;
+}
+
+.password-wrapper input {
+  flex: 1;
+  padding-right: 3.5rem;
+}
+
+.password-toggle {
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: var(--primary-color);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 0.25rem 0.375rem;
+}
+
+.password-toggle:hover {
+  color: var(--primary-hover);
+}
+
 .auth-divider {
   display: flex;
   align-items: center;

--- a/public/js/password-toggle.js
+++ b/public/js/password-toggle.js
@@ -1,0 +1,8 @@
+document.querySelectorAll('.password-toggle').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    const input = document.getElementById(btn.dataset.target);
+    const isPassword = input.type === 'password';
+    input.type = isPassword ? 'text' : 'password';
+    btn.textContent = isPassword ? 'Hide' : 'Show';
+  });
+});

--- a/src/views/components.tsx
+++ b/src/views/components.tsx
@@ -29,6 +29,33 @@ export const FormGroup: FC<
   </div>
 );
 
+export const PasswordInput: FC<{
+  id: string;
+  name: string;
+  autocomplete: string;
+  required?: boolean;
+  minlength?: number;
+}> = ({ id, name, autocomplete, required, minlength }) => (
+  <div class="password-wrapper">
+    <input
+      type="password"
+      id={id}
+      name={name}
+      autocomplete={autocomplete}
+      required={required}
+      minlength={minlength}
+    />
+    <button
+      type="button"
+      class="password-toggle"
+      aria-label="Toggle password visibility"
+      data-target={id}
+    >
+      Show
+    </button>
+  </div>
+);
+
 export const OtpInput: FC<{
   id: string;
   name: string;

--- a/src/views/pages/register.tsx
+++ b/src/views/pages/register.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'hono/jsx';
-import { Alert, AuthCard, FormGroup } from '../components';
+import { Alert, AuthCard, FormGroup, PasswordInput } from '../components';
 import { Layout } from '../layout';
 
 export interface RegisterPageProps {
@@ -30,8 +30,7 @@ export const RegisterPage: FC<RegisterPageProps> = ({ error }) => (
         </FormGroup>
 
         <FormGroup label="Password" htmlFor="password">
-          <input
-            type="password"
+          <PasswordInput
             id="password"
             name="password"
             autocomplete="new-password"
@@ -41,8 +40,7 @@ export const RegisterPage: FC<RegisterPageProps> = ({ error }) => (
         </FormGroup>
 
         <FormGroup label="Confirm Password" htmlFor="confirm_password">
-          <input
-            type="password"
+          <PasswordInput
             id="confirm_password"
             name="confirm_password"
             autocomplete="new-password"
@@ -59,5 +57,6 @@ export const RegisterPage: FC<RegisterPageProps> = ({ error }) => (
         Already have an account? <a href="/login">Login</a>
       </p>
     </AuthCard>
+    <script src="/js/password-toggle.js" />
   </Layout>
 );


### PR DESCRIPTION
## Summary

- Adds a Show/Hide toggle button to both Password and Confirm Password fields on the register form
- Creates a reusable `PasswordInput` component in `components.tsx`
- Browsers block copying from `type="password"` fields, so users couldn't copy-paste between the two fields — this toggle lets them reveal and verify their input

Closes #27

## Test plan

- [ ] Go to `/register`, verify both password fields show a "Show" button
- [ ] Click "Show" — field switches to plaintext, button says "Hide"
- [ ] Click "Hide" — field switches back to masked, button says "Show"
- [ ] Type password, click Show, select & copy, paste into Confirm — form submits successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)