### PR TITLE
feat: add logging service with log levels and configurable outputs

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -3,6 +3,7 @@
 const AdminPanel = {
   currentUserId: null,
   totpInterval: null,
+  _logger: Logger.create('AdminPanel'),
 
   async init() {
     await this.refreshAll();
@@ -43,7 +44,7 @@ const AdminPanel = {
         )
         .join('');
     } catch (err) {
-      console.error('Failed to load users:', err);
+      this._logger.error('Failed to load users:', err);
     }
   },
 
@@ -53,10 +54,7 @@ const AdminPanel = {
       const data = await res.json();
 
       if (!data.success) {
-        console.error(
-          '[AdminPanel] Failed to load user details - Status:',
-          data.error,
-        );
+        this._logger.error('Failed to load user details:', data.error);
         return;
       }
 
@@ -188,10 +186,7 @@ const AdminPanel = {
 
       this.showModal(html);
     } catch (err) {
-      console.error(
-        '[AdminPanel] Failed to load user details - Exception:',
-        err,
-      );
+      this._logger.error('Failed to load user details:', err);
     }
   },
 
@@ -234,21 +229,15 @@ const AdminPanel = {
       if (data.success) {
         this.closeModal();
         await this.loadUsers();
-        console.log(
-          '[AdminPanel] User created successfully - Username:',
+        this._logger.info(
+          'User created successfully - Username:',
           data.user?.username || 'unknown',
         );
       } else {
-        console.error(
-          '[AdminPanel] Failed to create user - Status:',
-          data.error,
-        );
+        this._logger.error('Failed to create user:', data.error);
       }
     } catch (err) {
-      console.error(
-        '[AdminPanel] Error creating user - Exception:',
-        err.message,
-      );
+      this._logger.error('Error creating user:', err.message);
     }
   },
 
@@ -262,21 +251,12 @@ const AdminPanel = {
       if (data.success) {
         this.closeModal();
         await this.loadUsers();
-        console.log(
-          '[AdminPanel] User deleted successfully - User ID:',
-          userId,
-        );
+        this._logger.info('User deleted successfully - User ID:', userId);
       } else {
-        console.error(
-          '[AdminPanel] Failed to delete user - Status:',
-          data.error,
-        );
+        this._logger.error('Failed to delete user:', data.error);
       }
     } catch (err) {
-      console.error(
-        '[AdminPanel] Error deleting user - Exception:',
-        err.message,
-      );
+      this._logger.error('Error deleting user:', err.message);
     }
   },
 
@@ -307,22 +287,13 @@ const AdminPanel = {
       const data = await res.json();
 
       if (data.success) {
-        console.log(
-          '[AdminPanel] Password reset successfully - User ID:',
-          userId,
-        );
+        this._logger.info('Password reset successfully - User ID:', userId);
         this.showUserDetails(userId);
       } else {
-        console.error(
-          '[AdminPanel] Failed to reset password - Status:',
-          data.error,
-        );
+        this._logger.error('Failed to reset password:', data.error);
       }
     } catch (err) {
-      console.error(
-        '[AdminPanel] Error resetting password - Exception:',
-        err.message,
-      );
+      this._logger.error('Error resetting password:', err.message);
     }
   },
 
@@ -348,7 +319,7 @@ const AdminPanel = {
             data.remainingSeconds;
         }
       } catch (err) {
-        console.error('Failed to get TOTP code:', err);
+        this._logger.error('Failed to get TOTP code:', err);
       }
     };
 
@@ -364,24 +335,18 @@ const AdminPanel = {
       const data = await res.json();
 
       if (data.success) {
-        console.info(
-          '[AdminPanel] Email code generated - Code:',
+        this._logger.info(
+          'Email code generated - Code:',
           data.code.code,
           '- Expires:',
           new Date(data.code.expiresAt).toLocaleTimeString(),
         );
         this.showUserDetails(userId);
       } else {
-        console.error(
-          '[AdminPanel] Failed to generate email code - Status:',
-          data.error,
-        );
+        this._logger.error('Failed to generate email code:', data.error);
       }
     } catch (err) {
-      console.error(
-        '[AdminPanel] Error generating email code - Exception:',
-        err.message,
-      );
+      this._logger.error('Error generating email code:', err.message);
     }
   },
 
@@ -399,21 +364,15 @@ const AdminPanel = {
 
       if (data.success) {
         this.showUserDetails(userId);
-        console.log(
-          '[AdminPanel] Passkey deleted successfully - Credential ID:',
+        this._logger.info(
+          'Passkey deleted successfully - Credential ID:',
           credentialId,
         );
       } else {
-        console.error(
-          '[AdminPanel] Failed to delete passkey - Status:',
-          data.error,
-        );
+        this._logger.error('Failed to delete passkey:', data.error);
       }
     } catch (err) {
-      console.error(
-        '[AdminPanel] Error deleting passkey - Exception:',
-        err.message,
-      );
+      this._logger.error('Error deleting passkey:', err.message);
     }
   },
 
@@ -446,7 +405,7 @@ const AdminPanel = {
         )
         .join('');
     } catch (err) {
-      console.error('Failed to load sessions:', err);
+      this._logger.error('Failed to load sessions:', err);
     }
   },
 
@@ -462,21 +421,15 @@ const AdminPanel = {
         if (this.currentUserId) {
           this.showUserDetails(this.currentUserId);
         }
-        console.log(
-          '[AdminPanel] Session deleted successfully - Session ID:',
+        this._logger.info(
+          'Session deleted successfully - Session ID:',
           sessionId,
         );
       } else {
-        console.error(
-          '[AdminPanel] Failed to delete session - Status:',
-          data.error,
-        );
+        this._logger.error('Failed to delete session:', data.error);
       }
     } catch (err) {
-      console.error(
-        '[AdminPanel] Error deleting session - Exception:',
-        err.message,
-      );
+      this._logger.error('Error deleting session:', err.message);
     }
   },
 
@@ -493,22 +446,16 @@ const AdminPanel = {
       const data = await res.json();
 
       if (data.success) {
-        console.log(
-          '[AdminPanel] All sessions deleted successfully - Count:',
+        this._logger.info(
+          'All sessions deleted successfully - Count:',
           data.deletedCount,
         );
         await this.loadSessions();
       } else {
-        console.error(
-          '[AdminPanel] Failed to kill sessions - Status:',
-          data.error,
-        );
+        this._logger.error('Failed to kill sessions:', data.error);
       }
     } catch (err) {
-      console.error(
-        '[AdminPanel] Error killing sessions - Exception:',
-        err.message,
-      );
+      this._logger.error('Error killing sessions:', err.message);
     }
   },
 
@@ -527,21 +474,13 @@ const AdminPanel = {
       const data = await res.json();
 
       if (data.success) {
-        console.log(
-          '[AdminPanel] Database reset successfully - reloading page',
-        );
+        this._logger.info('Database reset successfully - reloading page');
         window.location.reload();
       } else {
-        console.error(
-          '[AdminPanel] Failed to reset database - Status:',
-          data.error,
-        );
+        this._logger.error('Failed to reset database:', data.error);
       }
     } catch (err) {
-      console.error(
-        '[AdminPanel] Error resetting database - Exception:',
-        err.message,
-      );
+      this._logger.error('Error resetting database:', err.message);
     }
   },
 
@@ -555,7 +494,7 @@ const AdminPanel = {
         button.textContent = original;
       }, 1500);
     } catch (err) {
-      console.error('[AdminPanel] Failed to copy to clipboard:', err);
+      this._logger.error('Failed to copy to clipboard:', err);
     }
   },
 

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -1,3 +1,5 @@
+const _dashboardLogger = Logger.create('Dashboard');
+
 async function showTotpSetup() {
   const modal = document.getElementById('totp-setup-modal');
   const loading = document.getElementById('totp-setup-loading');
@@ -71,10 +73,10 @@ async function deletePasskey(credentialId) {
     if (data.success) {
       window.location.reload();
     } else {
-      alert(`Failed to remove passkey: ${data.error}`);
+      _dashboardLogger.error('Failed to remove passkey:', data.error);
     }
   } catch (err) {
-    alert(`Error removing passkey: ${err.message}`);
+    _dashboardLogger.error('Error removing passkey:', err.message);
   }
 }
 

--- a/public/js/logger.js
+++ b/public/js/logger.js
@@ -1,0 +1,54 @@
+// Centralized logging service with log levels and pluggable outputs
+
+const LOG_LEVELS = { debug: 0, info: 1, warn: 2, error: 3 };
+
+const ConsoleOutput = {
+  log(level, moduleName, message, ...args) {
+    const prefix = `[${moduleName}]`;
+    const fn =
+      level === 'debug'
+        ? console.debug
+        : level === 'info'
+          ? console.info
+          : level === 'warn'
+            ? console.warn
+            : console.error;
+    fn(prefix, message, ...args);
+  },
+};
+
+const Logger = {
+  _level: LOG_LEVELS.debug,
+  _outputs: [ConsoleOutput],
+
+  setLevel(level) {
+    if (!(level in LOG_LEVELS)) {
+      console.error(`[Logger] Unknown log level: ${level}`);
+      return;
+    }
+    this._level = LOG_LEVELS[level];
+  },
+
+  addOutput(output) {
+    this._outputs.push(output);
+  },
+
+  removeOutput(output) {
+    this._outputs = this._outputs.filter((o) => o !== output);
+  },
+
+  create(moduleName) {
+    const instance = {};
+    for (const level of Object.keys(LOG_LEVELS)) {
+      instance[level] = (message, ...args) => {
+        if (LOG_LEVELS[level] < this._level) return;
+        for (const output of this._outputs) {
+          output.log(level, moduleName, message, ...args);
+        }
+      };
+    }
+    return instance;
+  },
+};
+
+window.Logger = Logger;

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -1,4 +1,5 @@
 (() => {
+  const _loginLogger = Logger.create('Login');
   const usernameInput = document.getElementById('username');
   const mfaCheckbox = document.getElementById('require_2fa');
   const mfaLabel = document.getElementById('mfa-label');
@@ -42,7 +43,7 @@
         mfaLabel.title = TOOLTIP_NO_MFA;
       }
     } catch (e) {
-      console.error('[Login] MFA status check failed:', e);
+      _loginLogger.error('MFA status check failed:', e);
     }
   }
 

--- a/public/js/passkey-auto.js
+++ b/public/js/passkey-auto.js
@@ -1,13 +1,13 @@
 (() => {
+  const _passkeyAutoLogger = Logger.create('PasskeyAuto');
   document.addEventListener('DOMContentLoaded', async () => {
     const el = document.getElementById('passkey-config');
     const mediation = el?.dataset.mediation || undefined;
     try {
       await window.WebAuthnClient.loginWithPasskey(mediation);
     } catch (e) {
-      console.error(
-        '[PasskeyAuto] Auto-trigger failed (mediation=%s):',
-        mediation,
+      _passkeyAutoLogger.error(
+        `Auto-trigger failed (mediation=${mediation}):`,
         e,
       );
     }

--- a/public/js/webauthn.js
+++ b/public/js/webauthn.js
@@ -1,6 +1,8 @@
 // WebAuthn Client-side helpers
 
 const WebAuthnClient = {
+  _logger: Logger.create('WebAuthnClient'),
+
   // Convert base64url to ArrayBuffer
   base64urlToBuffer(base64url) {
     const padding = '='.repeat((4 - (base64url.length % 4)) % 4);
@@ -37,8 +39,8 @@ const WebAuthnClient = {
       const optionsData = await optionsRes.json();
 
       if (!optionsData.success) {
-        console.error(
-          '[WebAuthnClient] Failed to get registration options - Status:',
+        this._logger.error(
+          'Failed to get registration options:',
           optionsData.error,
         );
         return;
@@ -97,29 +99,16 @@ const WebAuthnClient = {
       const verifyData = await verifyRes.json();
 
       if (verifyData.success) {
-        console.log('[WebAuthnClient] Passkey registered successfully');
+        this._logger.info('Passkey registered successfully');
         window.location.reload();
       } else {
-        console.error(
-          '[WebAuthnClient] Failed to register passkey - Status:',
-          verifyData.error,
-        );
+        this._logger.error('Failed to register passkey:', verifyData.error);
       }
     } catch (error) {
-      console.error(
-        '[WebAuthnClient] Passkey registration error - Exception:',
-        error,
+      this._logger.error(
+        `Passkey registration error (${error.name}):`,
+        error.message,
       );
-      if (error.name === 'NotAllowedError') {
-        console.warn(
-          '[WebAuthnClient] Passkey registration cancelled or not allowed by user',
-        );
-      } else {
-        console.error(
-          '[WebAuthnClient] Error registering passkey - Exception:',
-          error.message,
-        );
-      }
     }
   },
 
@@ -134,8 +123,8 @@ const WebAuthnClient = {
       const optionsData = await optionsRes.json();
 
       if (!optionsData.success) {
-        console.error(
-          '[WebAuthnClient] Failed to get authentication options - Status:',
+        this._logger.error(
+          'Failed to get authentication options:',
           optionsData.error,
         );
         return;
@@ -160,7 +149,7 @@ const WebAuthnClient = {
         mediation,
       });
 
-      console.log('web app credential received', credential);
+      this._logger.debug('Credential received', credential);
 
       // Prepare response for server
       const response = {
@@ -190,34 +179,22 @@ const WebAuthnClient = {
       });
       const verifyData = await verifyRes.json();
 
-      console.log('passkey verification response', verifyData);
+      this._logger.debug('Verification response', verifyData);
+
       if (verifyData.success) {
-        console.log(
-          '[WebAuthnClient] Passkey authentication successful - action:',
+        this._logger.info(
+          'Passkey authentication successful - action:',
           verifyData.action,
         );
         window.location.href = '/dashboard';
       } else {
-        console.error(
-          '[WebAuthnClient] Passkey authentication failed - Status:',
-          verifyData.error,
-        );
+        this._logger.error('Passkey authentication failed:', verifyData.error);
       }
     } catch (error) {
-      console.error(
-        '[WebAuthnClient] Passkey authentication error - Exception:',
-        error,
+      this._logger.error(
+        `Passkey authentication error (${error.name}):`,
+        error.message,
       );
-      if (error.name === 'NotAllowedError') {
-        console.warn(
-          '[WebAuthnClient] Passkey authentication cancelled or not allowed by user',
-        );
-      } else {
-        console.error(
-          '[WebAuthnClient] Error authenticating with passkey - Exception:',
-          error.message,
-        );
-      }
     }
   },
 };

--- a/src/views/layout.tsx
+++ b/src/views/layout.tsx
@@ -122,6 +122,7 @@ export const Layout: FC<PropsWithChildren<LayoutProps>> = ({
           <div id="admin-modal-body"></div>
         </div>
       </div>
+      <script src="/js/logger.js"></script>
       <script src="/js/webauthn.js"></script>
       <script src="/js/admin.js"></script>
     </body>


### PR DESCRIPTION
## Summary
Closes #1

- Add a centralized logging service with log levels (debug, info, warn, error)
- Configurable output targets (console output for now, extensible for UI notifications later)
- Replace scattered `console.log`/`console.error` calls in WebAuthn client code with the logging service
- Surface specific `DOMException.name` in error messages instead of generic error strings

## Context
The app currently uses `alert()` for some errors (which steals focus) and raw `console.log` for others. This makes it hard to debug extension interactions, especially when testing concurrent passkey requests.

History tab split to #34.

## Test plan
- [ ] Verify passkey registration errors show specific `DOMException.name`
- [ ] Verify passkey authentication errors show specific `DOMException.name`
- [ ] Verify log levels filter correctly (e.g., setting level to `warn` suppresses `info`/`debug`)
- [ ] Verify existing passkey flows still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)