### PR TITLE
feat: multi-step identifier-first login flow

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -827,6 +827,29 @@ body {
   border-radius: 0 0 0.375rem 0.375rem;
 }
 
+/* Multi-step Login */
+
+#identity-display {
+  font-weight: 600;
+  padding: 0.5rem 0;
+  color: var(--text-color);
+}
+
+#back-btn {
+  display: block;
+  background: none;
+  border: none;
+  color: var(--primary-color);
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 0;
+  margin-top: 0.75rem;
+}
+
+#back-btn:hover {
+  text-decoration: underline;
+}
+
 /* Variant Picker */
 .variant-picker {
   display: flex;

--- a/public/js/multi-step-login.js
+++ b/public/js/multi-step-login.js
@@ -6,58 +6,61 @@
   const identityDisplay = document.getElementById('identity-display');
   const form = document.querySelector('form[method="post"]');
 
-  if (!step1 || !step2 || !continueBtn || !backBtn || !form) return;
-
-  const keepInDomCheckbox = form.querySelector(
-    'input[name="keep_identity_in_dom"]',
-  );
-  const clearFieldsCheckbox = form.querySelector('input[name="clear_fields"]');
-
-  // Enforce mutual exclusivity between sub-variant checkboxes
-  if (keepInDomCheckbox && clearFieldsCheckbox) {
-    keepInDomCheckbox.addEventListener('change', () => {
-      if (keepInDomCheckbox.checked) clearFieldsCheckbox.checked = false;
+  if (
+    !step1 ||
+    !step2 ||
+    !continueBtn ||
+    !backBtn ||
+    !identityDisplay ||
+    !form
+  ) {
+    console.error('[multi-step-login] Missing required DOM elements', {
+      step1: !!step1,
+      step2: !!step2,
+      continueBtn: !!continueBtn,
+      backBtn: !!backBtn,
+      identityDisplay: !!identityDisplay,
+      form: !!form,
     });
-    clearFieldsCheckbox.addEventListener('change', () => {
-      if (clearFieldsCheckbox.checked) keepInDomCheckbox.checked = false;
-    });
+    return;
   }
 
+  const clearFieldsCheckbox = form.querySelector('input[name="clear_fields"]');
+
   let storedUsername = '';
+  let clearFieldsAtContinue = false;
 
   continueBtn.addEventListener('click', () => {
     const usernameInput = document.getElementById('username');
     if (!usernameInput) return;
 
-    const username = usernameInput.value.trim();
-    if (!username) {
-      usernameInput.focus();
+    if (!usernameInput.value.trim()) {
+      usernameInput.reportValidity();
       return;
     }
 
-    storedUsername = username;
+    storedUsername = usernameInput.value.trim();
+    clearFieldsAtContinue = !!clearFieldsCheckbox?.checked;
 
     // Transition to step 2
     step1.style.display = 'none';
     step2.style.display = '';
 
-    const clearFields = clearFieldsCheckbox?.checked;
-
-    if (clearFields) {
+    if (clearFieldsAtContinue) {
       // Remove username input from DOM, add hidden input for form submission
-      usernameInput.remove();
       identityDisplay.style.display = 'none';
+      usernameInput.remove();
 
       const hidden = document.createElement('input');
       hidden.type = 'hidden';
       hidden.name = 'username';
       hidden.id = 'username-hidden';
-      hidden.value = username;
+      hidden.value = storedUsername;
       form.appendChild(hidden);
     } else {
       // Keep username input in DOM as hidden field
       usernameInput.type = 'hidden';
-      identityDisplay.textContent = username;
+      identityDisplay.textContent = storedUsername;
       identityDisplay.style.display = '';
     }
 
@@ -68,9 +71,7 @@
     step2.style.display = 'none';
     step1.style.display = '';
 
-    const clearFields = clearFieldsCheckbox?.checked;
-
-    if (clearFields) {
+    if (clearFieldsAtContinue) {
       // Remove the hidden input we created
       const hiddenInput = document.getElementById('username-hidden');
       if (hiddenInput) hiddenInput.remove();
@@ -78,8 +79,7 @@
       // Re-create the username input in the form group
       const formGroup = step1.querySelector('.form-group');
       if (formGroup) {
-        // Check if a wrapper div exists (from FormGroup component)
-        const existingInput = formGroup.querySelector('input');
+        const existingInput = formGroup.querySelector('input[name="username"]');
         if (!existingInput) {
           const newInput = document.createElement('input');
           newInput.type = 'text';

--- a/public/js/multi-step-login.js
+++ b/public/js/multi-step-login.js
@@ -1,0 +1,105 @@
+(() => {
+  const step1 = document.getElementById('step-1');
+  const step2 = document.getElementById('step-2');
+  const continueBtn = document.getElementById('continue-btn');
+  const backBtn = document.getElementById('back-btn');
+  const identityDisplay = document.getElementById('identity-display');
+  const form = document.querySelector('form[method="post"]');
+
+  if (!step1 || !step2 || !continueBtn || !backBtn || !form) return;
+
+  const keepInDomCheckbox = form.querySelector(
+    'input[name="keep_identity_in_dom"]',
+  );
+  const clearFieldsCheckbox = form.querySelector('input[name="clear_fields"]');
+
+  // Enforce mutual exclusivity between sub-variant checkboxes
+  if (keepInDomCheckbox && clearFieldsCheckbox) {
+    keepInDomCheckbox.addEventListener('change', () => {
+      if (keepInDomCheckbox.checked) clearFieldsCheckbox.checked = false;
+    });
+    clearFieldsCheckbox.addEventListener('change', () => {
+      if (clearFieldsCheckbox.checked) keepInDomCheckbox.checked = false;
+    });
+  }
+
+  let storedUsername = '';
+
+  continueBtn.addEventListener('click', () => {
+    const usernameInput = document.getElementById('username');
+    if (!usernameInput) return;
+
+    const username = usernameInput.value.trim();
+    if (!username) {
+      usernameInput.focus();
+      return;
+    }
+
+    storedUsername = username;
+
+    // Transition to step 2
+    step1.style.display = 'none';
+    step2.style.display = '';
+
+    const clearFields = clearFieldsCheckbox?.checked;
+
+    if (clearFields) {
+      // Remove username input from DOM, add hidden input for form submission
+      usernameInput.remove();
+      identityDisplay.style.display = 'none';
+
+      const hidden = document.createElement('input');
+      hidden.type = 'hidden';
+      hidden.name = 'username';
+      hidden.id = 'username-hidden';
+      hidden.value = username;
+      form.appendChild(hidden);
+    } else {
+      // Keep username input in DOM as hidden field
+      usernameInput.type = 'hidden';
+      identityDisplay.textContent = username;
+      identityDisplay.style.display = '';
+    }
+
+    document.getElementById('password')?.focus();
+  });
+
+  backBtn.addEventListener('click', () => {
+    step2.style.display = 'none';
+    step1.style.display = '';
+
+    const clearFields = clearFieldsCheckbox?.checked;
+
+    if (clearFields) {
+      // Remove the hidden input we created
+      const hiddenInput = document.getElementById('username-hidden');
+      if (hiddenInput) hiddenInput.remove();
+
+      // Re-create the username input in the form group
+      const formGroup = step1.querySelector('.form-group');
+      if (formGroup) {
+        // Check if a wrapper div exists (from FormGroup component)
+        const existingInput = formGroup.querySelector('input');
+        if (!existingInput) {
+          const newInput = document.createElement('input');
+          newInput.type = 'text';
+          newInput.id = 'username';
+          newInput.name = 'username';
+          newInput.autocomplete = 'username';
+          newInput.required = true;
+          newInput.value = storedUsername;
+          formGroup.appendChild(newInput);
+        }
+      }
+    } else {
+      // Restore username input to visible text type
+      const usernameInput = document.getElementById('username');
+      if (usernameInput) {
+        usernameInput.type = 'text';
+      }
+      identityDisplay.style.display = 'none';
+    }
+
+    document.getElementById('username')?.focus();
+  });
+})();

--- a/src/config/variants.ts
+++ b/src/config/variants.ts
@@ -129,6 +129,36 @@ export const VARIANTS: Variant[] = [
     type: 'checkbox',
     flows: ['login'],
   },
+  {
+    id: 'multi-step-login',
+    label: 'Multi-step (identifier first)',
+    description: 'Login with username first, then password on a second step',
+    tooltip:
+      'Navigates to /login/multi-step where the username and password are collected in two separate steps. Tests identifier-first login flows used by Google, Microsoft, etc.',
+    type: 'combo-option',
+    flows: ['login'],
+    group: 'login-method',
+  },
+  {
+    id: 'keep-identity-in-dom',
+    label: 'Keep identity in DOM',
+    description:
+      'Username field stays in DOM (hidden) when password step appears',
+    tooltip:
+      'After entering the username and advancing to step 2, the username input remains in the DOM as a hidden field. Password managers and extensions can still see both fields simultaneously.',
+    type: 'checkbox',
+    flows: ['multi-step-login'],
+  },
+  {
+    id: 'clear-fields',
+    label: 'Clear fields',
+    description:
+      'Username field is removed from DOM when password step appears',
+    tooltip:
+      'After entering the username and advancing to step 2, the username input is removed from the DOM entirely. Only a hidden input carries the value for form submission. Tests whether extensions can associate credentials when the identifier field is gone.',
+    type: 'checkbox',
+    flows: ['multi-step-login'],
+  },
 ];
 
 export function getVariantsByFlow(flow: string): Variant[] {

--- a/src/config/variants.ts
+++ b/src/config/variants.ts
@@ -140,22 +140,12 @@ export const VARIANTS: Variant[] = [
     group: 'login-method',
   },
   {
-    id: 'keep-identity-in-dom',
-    label: 'Keep identity in DOM',
-    description:
-      'Username field stays in DOM (hidden) when password step appears',
-    tooltip:
-      'After entering the username and advancing to step 2, the username input remains in the DOM as a hidden field. Password managers and extensions can still see both fields simultaneously.',
-    type: 'checkbox',
-    flows: ['multi-step-login'],
-  },
-  {
     id: 'clear-fields',
     label: 'Clear fields',
     description:
       'Username field is removed from DOM when password step appears',
     tooltip:
-      'After entering the username and advancing to step 2, the username input is removed from the DOM entirely. Only a hidden input carries the value for form submission. Tests whether extensions can associate credentials when the identifier field is gone.',
+      'After entering the username and advancing to step 2, the username input is removed from the DOM entirely. Only a hidden input carries the value for form submission. By default the username input stays in the DOM as a hidden field.',
     type: 'checkbox',
     flows: ['multi-step-login'],
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import dashboardRoutes from './routes/dashboard';
 import mfaRoutes from './routes/mfa';
 import webauthnRoutes from './routes/webauthn';
 import { Layout } from './views/layout';
+import { MultiStepLoginPage } from './views/pages/multi-step-login';
 import { PasskeyPage } from './views/pages/passkey';
 
 const app = new Hono();
@@ -50,9 +51,21 @@ app.get('/', (c) => {
         </ul>
         <p>Use this app to test password managers and browser extensions.</p>
         <div class="hero-actions">
-          <a href="/login" class="btn btn-primary">
-            Login
-          </a>
+          <div class="combo-btn">
+            <a href="/login" class="btn btn-primary combo-btn-main">
+              Login
+            </a>
+            <button
+              type="button"
+              class="btn btn-primary combo-btn-toggle"
+              onclick="this.parentElement.classList.toggle('open')"
+            >
+              &#9662;
+            </button>
+            <div class="combo-btn-dropdown">
+              <a href="/login/multi-step">Multi-step login</a>
+            </div>
+          </div>
           <a href="/register" class="btn btn-secondary">
             Register
           </a>
@@ -70,6 +83,9 @@ app.get('/register', (c) => c.redirect('/auth/register'));
 app.get('/passkey-conditional', (c) =>
   c.html(<PasskeyPage mediation="conditional" />),
 );
+
+// Multi-step login page (identifier-first flow)
+app.get('/login/multi-step', (c) => c.html(<MultiStepLoginPage />));
 
 // Start server
 const port = 3000;

--- a/src/routes/auth.tsx
+++ b/src/routes/auth.tsx
@@ -16,6 +16,7 @@ import {
 import type { ChangePasswordOptions } from '../views/pages/change-password';
 import { ChangePasswordPage } from '../views/pages/change-password';
 import { LoginPage } from '../views/pages/login';
+import { MultiStepLoginPage } from '../views/pages/multi-step-login';
 import { RegisterPage } from '../views/pages/register';
 
 const auth = new Hono();
@@ -43,10 +44,21 @@ auth.post('/login', async (c) => {
   const useFetch = body.use_fetch === '1';
   const stayOnPage = body.stay_on_page === '1';
   const redirectToLogin = body.redirect_to_login === '1';
+  const source = body.source as string | undefined;
   const ajax = useFetch && isAjax(c);
 
   const renderError = (error: string) => {
     if (ajax) return c.json({ error });
+    if (source === 'multi-step') {
+      return c.html(
+        <MultiStepLoginPage
+          error={error}
+          useFetch={useFetch}
+          stayOnPage={stayOnPage}
+          redirectToLogin={redirectToLogin}
+        />,
+      );
+    }
     return c.html(
       <LoginPage
         error={error}
@@ -108,8 +120,10 @@ auth.post('/login', async (c) => {
   }
 
   if (stayOnPage) {
+    const PageComponent =
+      source === 'multi-step' ? MultiStepLoginPage : LoginPage;
     return c.html(
-      <LoginPage
+      <PageComponent
         success="Logged in successfully"
         useFetch={useFetch}
         stayOnPage={stayOnPage}

--- a/src/routes/auth.tsx
+++ b/src/routes/auth.tsx
@@ -53,6 +53,7 @@ auth.post('/login', async (c) => {
       return c.html(
         <MultiStepLoginPage
           error={error}
+          username={username}
           useFetch={useFetch}
           stayOnPage={stayOnPage}
           redirectToLogin={redirectToLogin}

--- a/src/views/pages/login.tsx
+++ b/src/views/pages/login.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'hono/jsx';
-import { getVariantsByGroup } from '../../config/variants';
+import { getVariantById, getVariantsByGroup } from '../../config/variants';
 import {
   Alert,
   AuthCard,
@@ -82,9 +82,26 @@ export const LoginPage: FC<LoginPageProps> = ({
           checked={redirectToLogin}
         />
 
-        <button type="submit" class="btn btn-primary">
-          Login
-        </button>
+        <div class="combo-btn">
+          <button type="submit" class="btn btn-primary combo-btn-main">
+            Login
+          </button>
+          <button
+            type="button"
+            class="btn btn-primary combo-btn-toggle"
+            onclick="this.parentElement.classList.toggle('open')"
+          >
+            &#9662;
+          </button>
+          <div class="combo-btn-dropdown">
+            <a
+              href="/login/multi-step"
+              title={getVariantById('multi-step-login')?.tooltip}
+            >
+              Multi-step login
+            </a>
+          </div>
+        </div>
       </form>
 
       <div class="auth-divider">

--- a/src/views/pages/multi-step-login.tsx
+++ b/src/views/pages/multi-step-login.tsx
@@ -12,6 +12,7 @@ import { Layout } from '../layout';
 export interface MultiStepLoginPageProps {
   error?: string;
   success?: string;
+  username?: string;
   useFetch?: boolean;
   stayOnPage?: boolean;
   redirectToLogin?: boolean;
@@ -20,6 +21,7 @@ export interface MultiStepLoginPageProps {
 export const MultiStepLoginPage: FC<MultiStepLoginPageProps> = ({
   error,
   success,
+  username,
   useFetch,
   stayOnPage,
   redirectToLogin,
@@ -40,6 +42,7 @@ export const MultiStepLoginPage: FC<MultiStepLoginPageProps> = ({
               autocomplete="username"
               required
               autofocus
+              value={username}
             />
           </FormGroup>
 
@@ -85,7 +88,6 @@ export const MultiStepLoginPage: FC<MultiStepLoginPageProps> = ({
           </button>
         </div>
 
-        <VariantCheckbox variantId="keep-identity-in-dom" />
         <VariantCheckbox variantId="clear-fields" />
         <VariantCheckbox variantId="use-fetch" checked={useFetch} />
         <VariantCheckbox variantId="stay-on-page" checked={stayOnPage} />

--- a/src/views/pages/multi-step-login.tsx
+++ b/src/views/pages/multi-step-login.tsx
@@ -1,0 +1,107 @@
+import type { FC } from 'hono/jsx';
+import { getVariantById } from '../../config/variants';
+import {
+  Alert,
+  AuthCard,
+  FormGroup,
+  PasswordInput,
+  VariantCheckbox,
+} from '../components';
+import { Layout } from '../layout';
+
+export interface MultiStepLoginPageProps {
+  error?: string;
+  success?: string;
+  useFetch?: boolean;
+  stayOnPage?: boolean;
+  redirectToLogin?: boolean;
+}
+
+export const MultiStepLoginPage: FC<MultiStepLoginPageProps> = ({
+  error,
+  success,
+  useFetch,
+  stayOnPage,
+  redirectToLogin,
+}) => (
+  <Layout title="Multi-Step Login">
+    <AuthCard title="Multi-Step Login">
+      <Alert error={error} success={success} />
+
+      <form action="/auth/login" method="post" class="auth-form">
+        <input type="hidden" name="source" value="multi-step" />
+
+        <div id="step-1" class="login-step">
+          <FormGroup label="Username" htmlFor="username">
+            <input
+              type="text"
+              id="username"
+              name="username"
+              autocomplete="username"
+              required
+              autofocus
+            />
+          </FormGroup>
+
+          <button type="button" id="continue-btn" class="btn btn-primary">
+            Continue
+          </button>
+        </div>
+
+        <div id="step-2" class="login-step" style="display:none">
+          <div id="identity-display" style="display:none" />
+
+          <FormGroup label="Password" htmlFor="password">
+            <PasswordInput
+              id="password"
+              name="password"
+              autocomplete="current-password"
+              required
+            />
+          </FormGroup>
+
+          <div class="form-group">
+            <label
+              id="mfa-label"
+              title={getVariantById('require-2fa')?.tooltip}
+            >
+              <input
+                type="checkbox"
+                id="require_2fa"
+                name="require_2fa"
+                value="1"
+                disabled
+              />{' '}
+              Login with 2FA
+            </label>
+          </div>
+
+          <button type="submit" class="btn btn-primary">
+            Login
+          </button>
+
+          <button type="button" id="back-btn">
+            &larr; Back
+          </button>
+        </div>
+
+        <VariantCheckbox variantId="keep-identity-in-dom" />
+        <VariantCheckbox variantId="clear-fields" />
+        <VariantCheckbox variantId="use-fetch" checked={useFetch} />
+        <VariantCheckbox variantId="stay-on-page" checked={stayOnPage} />
+        <VariantCheckbox
+          variantId="redirect-to-login"
+          checked={redirectToLogin}
+        />
+      </form>
+
+      <p class="auth-link">
+        Or use the <a href="/login">standard login</a>
+      </p>
+    </AuthCard>
+    <script src="/js/login.js" />
+    <script src="/js/password-toggle.js" />
+    <script src="/js/form-submit.js" />
+    <script src="/js/multi-step-login.js" />
+  </Layout>
+);


### PR DESCRIPTION
## Summary
- Adds a two-step login flow at `/login/multi-step` where username and password are collected on separate steps, mirroring identifier-first patterns used by Google, Microsoft, etc.
- Includes a `clear-fields` variant checkbox that removes the username input from the DOM on step 2 (default keeps it as a hidden field)
- Accessible via combo button dropdowns on both the landing page and standard login page

Closes #36

## Test plan
- [ ] Navigate to `/login/multi-step` and complete a login (username → password)
- [ ] Use the Back button to return to step 1 and verify username is restored
- [ ] Toggle "Clear fields" checkbox and verify username input is removed from DOM on step 2
- [ ] Submit with empty username and verify browser validation feedback appears
- [ ] Trigger a server error (wrong password) and verify the page re-renders with the username pre-filled
- [ ] Verify combo button dropdowns appear on landing page and `/login` page
- [ ] Test with "Use fetch" and "Stay on page" variant checkboxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)